### PR TITLE
Complete mail integration: iTIP addressing, working ingress + reactive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/README.md
+++ b/README.md
@@ -55,23 +55,32 @@ Consume calendar object from HTTP endpoint:
 
 ### Email
 
-Publish calendar object via email:
+> **Note:** As of this release the mail channels require an explicit Jakarta Mail `Session`
+> (constructors no longer fall back to `Session.getDefaultInstance(null)`), and outgoing messages
+> derive their `From`/`To`/`Cc` from the calendar's `ORGANIZER`/`ATTENDEE` properties following the
+> iTIP (RFC 5546) `METHOD` matrix. Any addressing you set explicitly on the message overrides the
+> derived values. This is a **breaking** change to the channel/builder constructor signatures.
 
-    Calendar calendar = ...
+Publish a calendar object via email (recipients derived from the calendar):
+
+    Calendar calendar = ...   // ORGANIZER + ATTENDEEs + METHOD:REQUEST
+    Session session = ...     // configured with mail.smtp.host / mail.smtp.port
+    EgressChannel<Calendar> producer = new JakartaMailSMTPChannel(session);
+    producer.send(() -> calendar);
+
+Consume a calendar object delivered to an email address (polling the INBOX):
+
+    Session session = ...     // configured with an IMAP store
+    IngressChannel<Calendar> consumer = new JakartaMailPollingChannel(session,
+            new CalendarAttachmentProcessor());
+    consumer.poll(calendar -> { /* handle */ }, 30);
+
+Subscribe to calendar objects delivered to an email address (reactive, IMAP IDLE):
+
     Session session = ...
-    ChannelAdapter<Calendar> producer = new JakartaMailAdapter(session);
-    producer.send(calendar);
-
-Consume calendar object delivered to an email address:
-
-    Calendar calendar = null;
-    Session session = ...
-    ChannelConsumer<Calendar> consumer = new JakartaMailAdapter(session);
-    Calendar calendar = consumer.consume(c -> calendar = c, 30);
-
-Subscribe to calendar objects delivered to an email address:
-
-TBD.
+    JakartaMailPublisher publisher = new JakartaMailPublisher(session,
+            new CalendarAttachmentProcessor(), "INBOX");
+    publisher.subscribe(subscriber);
 
 ### Apache Camel
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ ical4j-vcard = "2.1.0"
 groovy = "3.0.22"
 log4j = "2.23.1"
 spock = "2.4-M4-groovy-3.0"
+greenmail = "2.0.1"
 
 
 [libraries]
@@ -17,3 +18,5 @@ log4j-slf4j2 = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version.
 
 spock-bom = { module = "org.spockframework:spock-bom", version.ref = "spock"}
 spock-core = { module = "org.spockframework:spock-core", version.ref = "spock"}
+
+greenmail = { module = "com.icegreen:greenmail", version.ref = "greenmail"}

--- a/ical4j-integration-mail/build.gradle
+++ b/ical4j-integration-mail/build.gradle
@@ -3,4 +3,7 @@ dependencies {
     api project(":ical4j-integration-api")
 
     api "com.sun.mail:jakarta.mail:$javamailVersion"
+
+    // in-JVM SMTP + IMAP (with IDLE) mail server for round-trip tests
+    testImplementation libs.greenmail
 }

--- a/ical4j-integration-mail/src/main/java/module-info.java
+++ b/ical4j-integration-mail/src/main/java/module-info.java
@@ -6,4 +6,7 @@ module ical4j.integration.mail {
     requires org.slf4j;
 
     exports org.ical4j.integration.mail;
+    exports org.ical4j.integration.mail.address;
+    exports org.ical4j.integration.mail.builder;
+    exports org.ical4j.integration.mail.processor;
 }

--- a/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/JakartaMailPollingChannel.java
+++ b/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/JakartaMailPollingChannel.java
@@ -1,8 +1,15 @@
 package org.ical4j.integration.mail;
 
-import jakarta.mail.*;
+import jakarta.mail.Flags;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
 import jakarta.mail.internet.MimeMessage;
 import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.model.Property;
+import net.fortuna.ical4j.model.component.CalendarComponent;
 import org.ical4j.integration.IngressChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,11 +19,15 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
- * Poll a mailbox for available calendar objects.
+ * Poll a mailbox for available calendar objects. Connects the store, opens the {@code INBOX}, and
+ * delivers parsed calendars to the consumer. Supports removing processed messages via
+ * {@code autoExpunge} or {@link #expunge(String)}.
  */
 public class JakartaMailPollingChannel implements IngressChannel<Calendar> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JakartaMailPollingChannel.class);
+
+    private static final String INBOX = "INBOX";
 
     private final Session session;
 
@@ -29,20 +40,114 @@ public class JakartaMailPollingChannel implements IngressChannel<Calendar> {
 
     @Override
     public boolean poll(Consumer<Calendar> consumer, long timeout) {
+        return poll(consumer, timeout, false);
+    }
+
+    @Override
+    public boolean poll(Consumer<Calendar> consumer, long timeout, boolean autoExpunge) {
+        Store store = null;
+        Folder inbox = null;
+        boolean consumed = false;
         try {
-            Store store = session.getStore();
-            Folder inbox = store.getDefaultFolder();
-            if (inbox.hasNewMessages()) {
-                for (int i = 0; i < inbox.getNewMessageCount(); i++) {
-                    Message message = inbox.getMessage(i);
-                    if (message instanceof MimeMessage) {
-                        messageProcessor.apply((MimeMessage) message).ifPresent(consumer);
+            store = session.getStore();
+            store.connect();
+            inbox = store.getFolder(INBOX);
+            inbox.open(autoExpunge ? Folder.READ_WRITE : Folder.READ_ONLY);
+
+            awaitMessages(inbox, timeout);
+
+            for (Message message : inbox.getMessages()) {
+                if (message instanceof MimeMessage) {
+                    Optional<Calendar> calendar = messageProcessor.apply((MimeMessage) message);
+                    if (calendar.isPresent()) {
+                        consumer.accept(calendar.get());
+                        consumed = true;
+                        if (autoExpunge) {
+                            message.setFlag(Flags.Flag.DELETED, true);
+                        }
                     }
                 }
             }
         } catch (MessagingException e) {
             LOGGER.error("Error retrieving messages", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            closeQuietly(inbox, autoExpunge);
+            closeQuietly(store);
+        }
+        return consumed;
+    }
+
+    @Override
+    public boolean expunge(String uid) {
+        Store store = null;
+        Folder inbox = null;
+        boolean found = false;
+        try {
+            store = session.getStore();
+            store.connect();
+            inbox = store.getFolder(INBOX);
+            inbox.open(Folder.READ_WRITE);
+            for (Message message : inbox.getMessages()) {
+                if (message instanceof MimeMessage) {
+                    Optional<Calendar> calendar = messageProcessor.apply((MimeMessage) message);
+                    if (calendar.isPresent() && matchesUid(calendar.get(), uid)) {
+                        message.setFlag(Flags.Flag.DELETED, true);
+                        found = true;
+                    }
+                }
+            }
+        } catch (MessagingException e) {
+            LOGGER.error("Error expunging message", e);
+        } finally {
+            closeQuietly(inbox, true);
+            closeQuietly(store);
+        }
+        return found;
+    }
+
+    /**
+     * Wait up to {@code timeout} seconds for at least one message to be available.
+     */
+    private void awaitMessages(Folder inbox, long timeout) throws MessagingException, InterruptedException {
+        long deadline = System.currentTimeMillis() + Math.max(0, timeout) * 1000L;
+        while (inbox.getMessageCount() == 0 && System.currentTimeMillis() < deadline) {
+            long remaining = deadline - System.currentTimeMillis();
+            if (remaining <= 0) {
+                break;
+            }
+            Thread.sleep(Math.min(500L, remaining));
+        }
+    }
+
+    private boolean matchesUid(Calendar calendar, String uid) {
+        for (CalendarComponent component : calendar.getComponents()) {
+            Optional<Property> property = component.getProperty(Property.UID);
+            if (property.isPresent() && uid.equals(property.get().getValue())) {
+                return true;
+            }
         }
         return false;
+    }
+
+    private void closeQuietly(Folder folder, boolean expunge) {
+        if (folder != null && folder.isOpen()) {
+            try {
+                folder.close(expunge);
+            } catch (MessagingException e) {
+                LOGGER.debug("Error closing folder", e);
+            }
+        }
+    }
+
+    private void closeQuietly(Store store) {
+        if (store != null && store.isConnected()) {
+            try {
+                store.close();
+            } catch (MessagingException e) {
+                LOGGER.debug("Error closing store", e);
+            }
+        }
     }
 }

--- a/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/JakartaMailPublisher.java
+++ b/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/JakartaMailPublisher.java
@@ -1,36 +1,66 @@
 package org.ical4j.integration.mail;
 
-import jakarta.mail.*;
-import jakarta.mail.event.ConnectionEvent;
-import jakarta.mail.event.ConnectionListener;
+import com.sun.mail.imap.IMAPFolder;
+import jakarta.mail.Folder;
+import jakarta.mail.FolderClosedException;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
 import jakarta.mail.event.MessageCountEvent;
 import jakarta.mail.event.MessageCountListener;
 import jakarta.mail.internet.MimeMessage;
 import net.fortuna.ical4j.model.Calendar;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.SubmissionPublisher;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
+/**
+ * A reactive {@link java.util.concurrent.Flow.Publisher} that emits calendar objects as matching
+ * messages arrive in the monitored folders. The publisher connects the mail store, opens each
+ * monitored folder, and maintains the connection via an IMAP IDLE keepalive (falling back to
+ * periodic polling for non-IMAP folders) so that message-count events continue to fire.
+ */
 public class JakartaMailPublisher extends SubmissionPublisher<Calendar>
-        implements MessageCountListener, ConnectionListener {
+        implements MessageCountListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JakartaMailPublisher.class);
+
+    private static final long POLL_INTERVAL_MS = 1000L;
 
     private final Function<MimeMessage, Optional<Calendar>> messageProcessor;
 
+    private final Store store;
+
+    private final List<Folder> folders = new ArrayList<>();
+
+    private final ExecutorService keepAliveExecutor;
+
+    private final AtomicBoolean running = new AtomicBoolean(true);
+
     public JakartaMailPublisher(Session session, Function<MimeMessage, Optional<Calendar>> messageProcessor,
-                                URLName...folders) {
+                                String... folderNames) {
         this.messageProcessor = messageProcessor;
         try {
-            session.getStore().addConnectionListener(this);
-            Arrays.stream(folders).forEach(f -> {
-                try {
-                    session.getFolder(f).addMessageCountListener(this);
-                } catch (MessagingException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        } catch (NoSuchProviderException e) {
+            this.store = session.getStore();
+            store.connect();
+            this.keepAliveExecutor = Executors.newCachedThreadPool();
+            for (String name : folderNames) {
+                Folder folder = store.getFolder(name);
+                folder.open(Folder.READ_ONLY);
+                folder.addMessageCountListener(this);
+                folders.add(folder);
+                keepAliveExecutor.submit(() -> keepAlive(folder));
+            }
+        } catch (MessagingException e) {
             throw new RuntimeException(e);
         }
     }
@@ -46,21 +76,56 @@ public class JakartaMailPublisher extends SubmissionPublisher<Calendar>
 
     @Override
     public void messagesRemoved(MessageCountEvent e) {
-
+        // no-op
     }
 
     @Override
-    public void opened(ConnectionEvent e) {
-
+    public void close() {
+        running.set(false);
+        for (Folder folder : folders) {
+            try {
+                if (folder.isOpen()) {
+                    folder.close(false);
+                }
+            } catch (MessagingException e) {
+                LOGGER.debug("Error closing folder", e);
+            }
+        }
+        keepAliveExecutor.shutdownNow();
+        try {
+            if (store.isConnected()) {
+                store.close();
+            }
+        } catch (MessagingException e) {
+            LOGGER.debug("Error closing store", e);
+        }
+        super.close();
     }
 
-    @Override
-    public void disconnected(ConnectionEvent e) {
-
-    }
-
-    @Override
-    public void closed(ConnectionEvent e) {
-        this.close();
+    /**
+     * Keep the folder connection live so new-message events are delivered. For IMAP this issues
+     * {@code IDLE}; for other providers it periodically refreshes the message count.
+     */
+    private void keepAlive(Folder folder) {
+        while (running.get() && folder.isOpen()) {
+            try {
+                if (folder instanceof IMAPFolder) {
+                    ((IMAPFolder) folder).idle();
+                } else {
+                    Thread.sleep(POLL_INTERVAL_MS);
+                    folder.getMessageCount();
+                }
+            } catch (FolderClosedException e) {
+                break;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (MessagingException e) {
+                if (running.get()) {
+                    LOGGER.warn("Keepalive stopped for folder", e);
+                }
+                break;
+            }
+        }
     }
 }

--- a/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/JakartaMailSMTPChannel.java
+++ b/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/JakartaMailSMTPChannel.java
@@ -1,39 +1,68 @@
 package org.ical4j.integration.mail;
 
 import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
 import jakarta.mail.Transport;
 import jakarta.mail.internet.MimeMessage;
 import net.fortuna.ical4j.model.Calendar;
 import org.ical4j.integration.EgressChannel;
+import org.ical4j.integration.mail.builder.EventAttachmentBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * Sends a calendar over SMTP. Messages are built via the supplied message builder and transported
+ * using the channel's {@link Session}, ensuring construction and transport share the same session.
+ */
 public class JakartaMailSMTPChannel implements EgressChannel<Calendar> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JakartaMailSMTPChannel.class);
 
+    private final Session session;
+
     private final Function<Calendar, Optional<MimeMessage>> messageBuilder;
 
-    public JakartaMailSMTPChannel(Function<Calendar, Optional<MimeMessage>> messageBuilder) {
+    /**
+     * Create a channel using the default {@link EventAttachmentBuilder} bound to the given session.
+     */
+    public JakartaMailSMTPChannel(Session session) {
+        this(session, new EventAttachmentBuilder(session));
+    }
+
+    public JakartaMailSMTPChannel(Session session, Function<Calendar, Optional<MimeMessage>> messageBuilder) {
+        this.session = session;
         this.messageBuilder = messageBuilder;
     }
 
     @Override
     public boolean send(Supplier<Calendar> supplier) {
-        AtomicBoolean sent = new AtomicBoolean(false);
-        messageBuilder.apply(supplier.get()).ifPresentOrElse(msg -> {
-            try {
-                Transport.send(msg);
-                sent.set(true);
-            } catch (MessagingException e) {
-                LOGGER.error("Error sending payload", e);
+        Optional<MimeMessage> message = messageBuilder.apply(supplier.get());
+        if (message.isEmpty()) {
+            LOGGER.info("No message produced for calendar; nothing to send");
+            return false;
+        }
+        MimeMessage msg = message.get();
+        Transport transport = null;
+        try {
+            transport = session.getTransport();
+            transport.connect();
+            transport.sendMessage(msg, msg.getAllRecipients());
+            return true;
+        } catch (MessagingException e) {
+            LOGGER.error("Error sending payload", e);
+            return false;
+        } finally {
+            if (transport != null) {
+                try {
+                    transport.close();
+                } catch (MessagingException e) {
+                    LOGGER.debug("Error closing transport", e);
+                }
             }
-        }, () -> LOGGER.info(""));
-        return sent.get();
+        }
     }
 }

--- a/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/address/Addressing.java
+++ b/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/address/Addressing.java
@@ -1,0 +1,54 @@
+package org.ical4j.integration.mail.address;
+
+import jakarta.mail.internet.InternetAddress;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Immutable value type describing the email envelope addressing derived from a calendar object:
+ * an optional {@code From} address and (possibly empty) {@code To} and {@code Cc} lists.
+ */
+public final class Addressing {
+
+    private final InternetAddress from;
+
+    private final List<InternetAddress> to;
+
+    private final List<InternetAddress> cc;
+
+    public Addressing(InternetAddress from, List<InternetAddress> to, List<InternetAddress> cc) {
+        this.from = from;
+        this.to = to != null ? List.copyOf(to) : Collections.emptyList();
+        this.cc = cc != null ? List.copyOf(cc) : Collections.emptyList();
+    }
+
+    /**
+     * @return the derived sender address, if one could be determined
+     */
+    public Optional<InternetAddress> getFrom() {
+        return Optional.ofNullable(from);
+    }
+
+    /**
+     * @return the derived primary recipients (never null, possibly empty)
+     */
+    public List<InternetAddress> getTo() {
+        return to;
+    }
+
+    /**
+     * @return the derived carbon-copy recipients (never null, possibly empty)
+     */
+    public List<InternetAddress> getCc() {
+        return cc;
+    }
+
+    /**
+     * @return true if no sender and no recipients could be derived
+     */
+    public boolean isEmpty() {
+        return from == null && to.isEmpty() && cc.isEmpty();
+    }
+}

--- a/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/address/ITipRecipientStrategy.java
+++ b/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/address/ITipRecipientStrategy.java
@@ -1,0 +1,168 @@
+package org.ical4j.integration.mail.address;
+
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
+import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.model.Property;
+import net.fortuna.ical4j.model.component.CalendarComponent;
+import net.fortuna.ical4j.model.parameter.Cn;
+import net.fortuna.ical4j.model.parameter.CuType;
+import net.fortuna.ical4j.model.parameter.SentBy;
+import net.fortuna.ical4j.model.property.Attendee;
+import net.fortuna.ical4j.model.property.Method;
+import net.fortuna.ical4j.model.property.Organizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Derives envelope addressing from an iCalendar object following the iTIP (RFC 5546) {@code METHOD}
+ * matrix:
+ *
+ * <pre>
+ *   REQUEST / CANCEL / ADD     organizer -&gt; attendees
+ *   REPLY / COUNTER / REFRESH  attendee  -&gt; organizer
+ *   DECLINECOUNTER             organizer -&gt; attendee
+ *   PUBLISH (or no method)     organizer -&gt; (caller-supplied recipients)
+ * </pre>
+ *
+ * <p>A {@code CAL-ADDRESS} value is mapped to an email address by stripping the {@code mailto:}
+ * scheme; the {@code CN} parameter supplies the personal name. The organizer {@code SENT-BY}
+ * parameter, when present, overrides the {@code From}. Attendees with {@code CUTYPE} of
+ * {@code RESOURCE} or {@code ROOM} are excluded. When the properties required for the method are
+ * absent (or an attendee-originated method has no single identifiable attendee), no addressing is
+ * derived and {@link Optional#empty()} is returned so the caller can supply addressing.</p>
+ */
+public class ITipRecipientStrategy implements RecipientStrategy {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ITipRecipientStrategy.class);
+
+    @Override
+    public Optional<Addressing> apply(Calendar calendar) {
+        String method = calendar.<Method>getProperty(Property.METHOD)
+                .map(Property::getValue).orElse(Method.VALUE_PUBLISH);
+
+        Optional<InternetAddress> organizer = firstOrganizer(calendar).flatMap(this::organizerAddress);
+        List<InternetAddress> attendees = attendeeAddresses(calendar);
+
+        Addressing addressing;
+        if (Method.VALUE_REQUEST.equals(method) || Method.VALUE_CANCEL.equals(method)
+                || Method.VALUE_ADD.equals(method)) {
+            // organizer -> attendees
+            if (organizer.isEmpty() || attendees.isEmpty()) {
+                return Optional.empty();
+            }
+            addressing = new Addressing(organizer.get(), attendees, null);
+        } else if (Method.VALUE_REPLY.equals(method) || Method.VALUE_COUNTER.equals(method)
+                || Method.VALUE_REFRESH.equals(method)) {
+            // attendee -> organizer (only when a single attendee can be identified)
+            if (organizer.isEmpty() || attendees.size() != 1) {
+                return Optional.empty();
+            }
+            addressing = new Addressing(attendees.get(0), List.of(organizer.get()), null);
+        } else if (Method.VALUE_DECLINECOUNTER.equals(method)) {
+            // organizer -> the attendee
+            if (organizer.isEmpty() || attendees.size() != 1) {
+                return Optional.empty();
+            }
+            addressing = new Addressing(organizer.get(), List.of(attendees.get(0)), null);
+        } else {
+            // PUBLISH (or unknown/no method): sender only, recipients supplied by the caller
+            if (organizer.isEmpty()) {
+                return Optional.empty();
+            }
+            addressing = new Addressing(organizer.get(), Collections.emptyList(), null);
+        }
+        return addressing.isEmpty() ? Optional.empty() : Optional.of(addressing);
+    }
+
+    private Optional<Organizer> firstOrganizer(Calendar calendar) {
+        for (CalendarComponent component : calendar.getComponents()) {
+            Optional<Organizer> organizer = component.getProperty(Property.ORGANIZER);
+            if (organizer.isPresent()) {
+                return organizer;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private List<InternetAddress> attendeeAddresses(Calendar calendar) {
+        // union of attendees across all components, de-duplicated by cal-address
+        Map<String, Attendee> byAddress = new LinkedHashMap<>();
+        for (CalendarComponent component : calendar.getComponents()) {
+            List<Attendee> attendees = component.getProperties(Property.ATTENDEE);
+            for (Attendee attendee : attendees) {
+                URI calAddress = attendee.getCalAddress();
+                String key = calAddress != null ? calAddress.toString() : attendee.getValue();
+                byAddress.putIfAbsent(key, attendee);
+            }
+        }
+        List<InternetAddress> result = new ArrayList<>();
+        for (Attendee attendee : byAddress.values()) {
+            attendeeAddress(attendee).ifPresent(result::add);
+        }
+        return result;
+    }
+
+    private Optional<InternetAddress> attendeeAddress(Attendee attendee) {
+        Optional<CuType> cuType = attendee.getParameter(Parameter.CUTYPE);
+        if (cuType.isPresent()) {
+            String value = cuType.get().getValue();
+            if (CuType.RESOURCE.getValue().equalsIgnoreCase(value)
+                    || CuType.ROOM.getValue().equalsIgnoreCase(value)) {
+                return Optional.empty();
+            }
+        }
+        return toAddress(attendee.getCalAddress(), attendee.getParameter(Parameter.CN));
+    }
+
+    private Optional<InternetAddress> organizerAddress(Organizer organizer) {
+        Optional<Cn> cn = organizer.getParameter(Parameter.CN);
+        Optional<SentBy> sentBy = organizer.getParameter(Parameter.SENT_BY);
+        if (sentBy.isPresent()) {
+            return toAddress(sentBy.get().getAddress(), cn);
+        }
+        return toAddress(organizer.getCalAddress(), cn);
+    }
+
+    private Optional<InternetAddress> toAddress(URI calAddress, Optional<Cn> cn) {
+        if (calAddress == null) {
+            return Optional.empty();
+        }
+        String scheme = calAddress.getScheme();
+        if (scheme == null || !"mailto".equalsIgnoreCase(scheme)) {
+            return Optional.empty();
+        }
+        String email = calAddress.getSchemeSpecificPart();
+        if (email == null || email.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            InternetAddress address = new InternetAddress(email.trim());
+            if (cn.isPresent()) {
+                address.setPersonal(cn.get().getValue());
+            }
+            return Optional.of(address);
+        } catch (AddressException | UnsupportedEncodingException e) {
+            LOGGER.warn("Skipping invalid calendar address: {}", calAddress, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Local constants for parameter names to avoid magic strings.
+     */
+    private static final class Parameter {
+        static final String CN = "CN";
+        static final String CUTYPE = "CUTYPE";
+        static final String SENT_BY = "SENT-BY";
+    }
+}

--- a/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/address/RecipientStrategy.java
+++ b/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/address/RecipientStrategy.java
@@ -1,0 +1,15 @@
+package org.ical4j.integration.mail.address;
+
+import net.fortuna.ical4j.model.Calendar;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Derives email envelope {@link Addressing} (from/to/cc) from an iCalendar object.
+ *
+ * <p>Implementations return {@link Optional#empty()} when addressing cannot be derived, leaving
+ * the caller responsible for setting addressing explicitly (caller override).</p>
+ */
+public interface RecipientStrategy extends Function<Calendar, Optional<Addressing>> {
+}

--- a/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/builder/EventAttachmentBuilder.java
+++ b/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/builder/EventAttachmentBuilder.java
@@ -1,5 +1,7 @@
 package org.ical4j.integration.mail.builder;
 
+import jakarta.mail.Address;
+import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeBodyPart;
@@ -7,68 +9,131 @@ import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
 import net.fortuna.ical4j.data.CalendarOutputter;
 import net.fortuna.ical4j.model.Calendar;
-import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.Property;
+import net.fortuna.ical4j.model.component.CalendarComponent;
 import net.fortuna.ical4j.model.property.Description;
+import net.fortuna.ical4j.model.property.Method;
 import net.fortuna.ical4j.model.property.StyledDescription;
 import net.fortuna.ical4j.model.property.Summary;
+import org.ical4j.integration.mail.address.Addressing;
+import org.ical4j.integration.mail.address.ITipRecipientStrategy;
+import org.ical4j.integration.mail.address.RecipientStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.function.Function;
 
+/**
+ * Builds a {@link MimeMessage} from a {@link Calendar}, attaching the calendar as a
+ * {@code text/calendar} part (with the iTIP {@code method} parameter) plus plain-text and optional
+ * HTML body parts. Envelope addressing is derived from the calendar via a {@link RecipientStrategy}
+ * by default; any addressing already set by the caller is preserved (caller override).
+ */
 public class EventAttachmentBuilder implements Function<Calendar, Optional<MimeMessage>> {
 
-    Logger LOGGER = LoggerFactory.getLogger(EventAttachmentBuilder.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventAttachmentBuilder.class);
+
+    private static final String STYLED_DESCRIPTION = "STYLED-DESCRIPTION";
+
+    private final Session session;
+
+    private final RecipientStrategy recipientStrategy;
+
+    public EventAttachmentBuilder(Session session) {
+        this(session, new ITipRecipientStrategy());
+    }
+
+    public EventAttachmentBuilder(Session session, RecipientStrategy recipientStrategy) {
+        this.session = session;
+        this.recipientStrategy = recipientStrategy;
+    }
 
     @Override
     public Optional<MimeMessage> apply(Calendar calendar) {
         try {
-            Optional<VEvent> event = calendar.getComponent("VEVENT");
-            if (event.isPresent()) {
-                Summary summary = event.get().getRequiredProperty("SUMMARY");
-                Optional<Description> description = event.get().getProperty("DESCRIPTION");
-                Optional<StyledDescription> styledDescription = event.get().getProperty("STYLED-DESCRIPTION");
-//                List<Participant> participantList = event.get().getComponents("PARTICIPANT");
-
-                StringWriter sout = new StringWriter();
-                CalendarOutputter calout = new CalendarOutputter();
-                calout.output(calendar, sout);
-
-                MimeBodyPart calpart = new MimeBodyPart();
-                calpart.setDisposition(MimeBodyPart.ATTACHMENT);
-                calpart.setFileName("calendar.ics");
-                calpart.setContent(sout.toString(), calendar.getContentType(StandardCharsets.US_ASCII));
-
-                MimeBodyPart textpart = new MimeBodyPart();
-                if (description.isPresent()) {
-                    textpart.setContent(description.get().getValue(), "text/plain; charset=UTF-8");
-                } else {
-                    textpart.setContent(summary.getValue(), "text/plain; charset=UTF-8");
-                }
-
-                MimeMultipart body = new MimeMultipart();
-                body.addBodyPart(calpart);
-                body.addBodyPart(textpart);
-
-                if (styledDescription.isPresent()) {
-                    MimeBodyPart htmlpart = new MimeBodyPart();
-                    htmlpart.setContent(styledDescription.get().getValue(), "text/html; charset=UTF-8");
-                    body.addBodyPart(htmlpart);
-                }
-
-                MimeMessage message = new MimeMessage(Session.getDefaultInstance(null));
-//                message.setFrom(template.getFromAddress());
-//                message.addRecipients(Message.RecipientType.TO, String.join(";", template.getToAddresses()));
-                message.setSubject(summary.getValue());
-                message.setContent(body);
-                return Optional.of(message);
+            if (calendar.getComponents().isEmpty()) {
+                return Optional.empty();
             }
+
+            Optional<Summary> summary = firstProperty(calendar, Property.SUMMARY);
+            Optional<Description> description = firstProperty(calendar, Property.DESCRIPTION);
+            Optional<StyledDescription> styledDescription = firstProperty(calendar, STYLED_DESCRIPTION);
+
+            StringWriter sout = new StringWriter();
+            new CalendarOutputter().output(calendar, sout);
+
+            String method = calendar.<Method>getProperty(Property.METHOD)
+                    .map(Property::getValue).orElse(null);
+
+            MimeBodyPart calpart = new MimeBodyPart();
+            calpart.setDisposition(MimeBodyPart.ATTACHMENT);
+            calpart.setFileName("calendar.ics");
+            StringBuilder contentType = new StringBuilder("text/calendar; charset=UTF-8");
+            if (method != null) {
+                contentType.append("; method=").append(method);
+            }
+            calpart.setContent(sout.toString(), contentType.toString());
+
+            MimeBodyPart textpart = new MimeBodyPart();
+            String text = description.map(Property::getValue)
+                    .orElseGet(() -> summary.map(Property::getValue).orElse(""));
+            textpart.setContent(text, "text/plain; charset=UTF-8");
+
+            MimeMultipart body = new MimeMultipart();
+            body.addBodyPart(calpart);
+            body.addBodyPart(textpart);
+
+            if (styledDescription.isPresent()) {
+                MimeBodyPart htmlpart = new MimeBodyPart();
+                htmlpart.setContent(styledDescription.get().getValue(), "text/html; charset=UTF-8");
+                body.addBodyPart(htmlpart);
+            }
+
+            MimeMessage message = new MimeMessage(session);
+            Optional<Addressing> addressing = recipientStrategy.apply(calendar);
+            if (addressing.isPresent()) {
+                applyAddressing(message, addressing.get());
+            }
+            if (summary.isPresent()) {
+                message.setSubject(summary.get().getValue());
+            }
+            message.setContent(body);
+            return Optional.of(message);
         } catch (IOException | MessagingException e) {
             LOGGER.error("Unexpected error", e);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Apply derived addressing only to fields the caller has not already set on the message.
+     */
+    private void applyAddressing(MimeMessage message, Addressing addressing) throws MessagingException {
+        if (addressing.getFrom().isPresent()
+                && (message.getFrom() == null || message.getFrom().length == 0)) {
+            message.setFrom(addressing.getFrom().get());
+        }
+        if (!addressing.getTo().isEmpty()
+                && message.getRecipients(Message.RecipientType.TO) == null) {
+            message.setRecipients(Message.RecipientType.TO,
+                    addressing.getTo().toArray(new Address[0]));
+        }
+        if (!addressing.getCc().isEmpty()
+                && message.getRecipients(Message.RecipientType.CC) == null) {
+            message.setRecipients(Message.RecipientType.CC,
+                    addressing.getCc().toArray(new Address[0]));
+        }
+    }
+
+    private <T extends Property> Optional<T> firstProperty(Calendar calendar, String name) {
+        for (CalendarComponent component : calendar.getComponents()) {
+            Optional<T> property = component.getProperty(name);
+            if (property.isPresent()) {
+                return property;
+            }
         }
         return Optional.empty();
     }

--- a/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/processor/CalendarAttachmentProcessor.java
+++ b/ical4j-integration-mail/src/main/java/org/ical4j/integration/mail/processor/CalendarAttachmentProcessor.java
@@ -3,7 +3,6 @@ package org.ical4j.integration.mail.processor;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Multipart;
 import jakarta.mail.Part;
-import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import net.fortuna.ical4j.data.CalendarBuilder;
 import net.fortuna.ical4j.data.ParserException;
@@ -11,33 +10,55 @@ import net.fortuna.ical4j.model.Calendar;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Optional;
 import java.util.function.Function;
 
+/**
+ * Extracts an iCalendar object from a message by locating a {@code text/calendar} part, whether it
+ * is an attachment, an inline body part, or the whole single-part message body.
+ */
 public class CalendarAttachmentProcessor implements Function<MimeMessage, Optional<Calendar>> {
 
-    Logger LOGGER = LoggerFactory.getLogger(CalendarAttachmentProcessor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CalendarAttachmentProcessor.class);
+
+    private static final String CALENDAR_MIME_TYPE = "text/calendar";
 
     @Override
     public Optional<Calendar> apply(MimeMessage mimeMessage) {
         try {
-            Multipart multiPart = (Multipart) mimeMessage.getContent();
-            int numberOfParts = multiPart.getCount();
-            for (int partCount = 0; partCount < numberOfParts; partCount++) {
-                MimeBodyPart part = (MimeBodyPart) multiPart.getBodyPart(partCount);
-                if (Part.ATTACHMENT.equalsIgnoreCase(part.getDisposition())) {
-                    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-                    part.writeTo(buffer);
-                    Calendar calendar = new CalendarBuilder().build(new ByteArrayInputStream(buffer.toByteArray()));
-                }
-            }
+            return fromPart(mimeMessage);
         } catch (IOException | MessagingException e) {
             LOGGER.error("Unexpected error", e);
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Calendar> fromPart(Part part) throws IOException, MessagingException {
+        if (part.isMimeType(CALENDAR_MIME_TYPE)) {
+            return parse(part);
+        }
+        Object content = part.getContent();
+        if (content instanceof Multipart) {
+            Multipart multipart = (Multipart) content;
+            for (int i = 0; i < multipart.getCount(); i++) {
+                Optional<Calendar> calendar = fromPart(multipart.getBodyPart(i));
+                if (calendar.isPresent()) {
+                    return calendar;
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Calendar> parse(Part part) {
+        try (InputStream in = part.getInputStream()) {
+            return Optional.of(new CalendarBuilder().build(in));
+        } catch (IOException | MessagingException e) {
+            LOGGER.error("Unexpected error reading calendar part", e);
         } catch (ParserException e) {
-            LOGGER.error("Invalid attachment", e);
+            LOGGER.error("Invalid calendar content", e);
         }
         return Optional.empty();
     }

--- a/ical4j-integration-mail/src/test/groovy/org/ical4j/integration/mail/AbstractGreenMailSpec.groovy
+++ b/ical4j-integration-mail/src/test/groovy/org/ical4j/integration/mail/AbstractGreenMailSpec.groovy
@@ -1,0 +1,78 @@
+package org.ical4j.integration.mail
+
+import com.icegreen.greenmail.util.GreenMail
+import com.icegreen.greenmail.util.ServerSetupTest
+import jakarta.mail.Authenticator
+import jakarta.mail.PasswordAuthentication
+import jakarta.mail.Session
+import net.fortuna.ical4j.model.Calendar
+import net.fortuna.ical4j.model.component.VEvent
+import net.fortuna.ical4j.model.property.Attendee
+import net.fortuna.ical4j.model.property.Method
+import net.fortuna.ical4j.model.property.Organizer
+import net.fortuna.ical4j.model.property.ProdId
+import net.fortuna.ical4j.model.property.Summary
+import net.fortuna.ical4j.model.property.Uid
+import net.fortuna.ical4j.model.property.immutable.ImmutableVersion
+import spock.lang.Specification
+
+/**
+ * Base specification that starts an in-JVM GreenMail server (SMTP + IMAP, with IDLE support) and
+ * provides a configured {@link Session} plus helpers for building test calendars.
+ */
+abstract class AbstractGreenMailSpec extends Specification {
+
+    static final String SENDER = 'sender@example.com'
+    static final String RECIPIENT = 'recipient@example.com'
+    static final String LOGIN = 'recipient'
+    static final String PASSWORD = 'password'
+
+    GreenMail greenMail
+
+    def setup() {
+        greenMail = new GreenMail(ServerSetupTest.SMTP_IMAP)
+        greenMail.start()
+        greenMail.setUser(RECIPIENT, LOGIN, PASSWORD)
+    }
+
+    def cleanup() {
+        greenMail?.stop()
+    }
+
+    Session mailSession() {
+        Properties props = new Properties()
+        props.setProperty('mail.smtp.host', 'localhost')
+        props.setProperty('mail.smtp.port', String.valueOf(greenMail.smtp.port))
+        props.setProperty('mail.transport.protocol', 'smtp')
+        props.setProperty('mail.store.protocol', 'imap')
+        props.setProperty('mail.imap.host', 'localhost')
+        props.setProperty('mail.imap.port', String.valueOf(greenMail.imap.port))
+        props.setProperty('mail.imap.user', LOGIN)
+        return Session.getInstance(props, new Authenticator() {
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(LOGIN, PASSWORD)
+            }
+        })
+    }
+
+    /**
+     * Build a minimal REQUEST calendar with the given organizer and attendees (bare email
+     * addresses; the {@code mailto:} scheme is added automatically).
+     */
+    static Calendar requestCalendar(String uid, String organizerEmail, List<String> attendeeEmails) {
+        VEvent event = new VEvent()
+        event = event.add(new Uid(uid))
+        event = event.add(new Summary('Test Event'))
+        event = event.add(new Organizer(URI.create('mailto:' + organizerEmail)))
+        for (String attendee : attendeeEmails) {
+            event = event.add(new Attendee(URI.create('mailto:' + attendee)))
+        }
+
+        Calendar calendar = new Calendar()
+        calendar = calendar.add(new ProdId('-//ical4j//integration test//EN'))
+        calendar = calendar.add(ImmutableVersion.VERSION_2_0)
+        calendar = calendar.add(new Method(Method.VALUE_REQUEST))
+        calendar = calendar.add(event)
+        return calendar
+    }
+}

--- a/ical4j-integration-mail/src/test/groovy/org/ical4j/integration/mail/JakartaMailPollingChannelSpec.groovy
+++ b/ical4j-integration-mail/src/test/groovy/org/ical4j/integration/mail/JakartaMailPollingChannelSpec.groovy
@@ -1,0 +1,67 @@
+package org.ical4j.integration.mail
+
+import net.fortuna.ical4j.model.Calendar
+import org.ical4j.integration.mail.processor.CalendarAttachmentProcessor
+
+class JakartaMailPollingChannelSpec extends AbstractGreenMailSpec {
+
+    def 'round-trips a calendar from SMTP send to IMAP poll'() {
+        given:
+        def session = mailSession()
+        def egress = new JakartaMailSMTPChannel(session)
+        def ingress = new JakartaMailPollingChannel(session, new CalendarAttachmentProcessor())
+
+        when: 'a calendar is sent and delivered'
+        egress.send { requestCalendar('round-trip-1', SENDER, [RECIPIENT]) }
+        greenMail.waitForIncomingEmail(5000, 1)
+
+        and: 'the inbox is polled'
+        List<Calendar> received = []
+        boolean consumed = ingress.poll({ received << it }, 5)
+
+        then:
+        consumed
+        received.size() == 1
+        received[0].getComponent('VEVENT').get().getRequiredProperty('UID').value == 'round-trip-1'
+    }
+
+    def 'autoExpunge removes the consumed message'() {
+        given:
+        def session = mailSession()
+        def egress = new JakartaMailSMTPChannel(session)
+        def ingress = new JakartaMailPollingChannel(session, new CalendarAttachmentProcessor())
+
+        when: 'a delivered message is polled with autoExpunge'
+        egress.send { requestCalendar('expunge-1', SENDER, [RECIPIENT]) }
+        greenMail.waitForIncomingEmail(5000, 1)
+        ingress.poll({ }, 5, true)
+
+        and: 'a second poll finds nothing'
+        List<Calendar> received = []
+        boolean consumed = ingress.poll({ received << it }, 2)
+
+        then:
+        !consumed
+        received.isEmpty()
+    }
+
+    def 'expunge by uid removes the matching message'() {
+        given:
+        def session = mailSession()
+        def egress = new JakartaMailSMTPChannel(session)
+        def ingress = new JakartaMailPollingChannel(session, new CalendarAttachmentProcessor())
+
+        when:
+        egress.send { requestCalendar('expunge-uid', SENDER, [RECIPIENT]) }
+        greenMail.waitForIncomingEmail(5000, 1)
+        boolean removed = ingress.expunge('expunge-uid')
+
+        and:
+        List<Calendar> received = []
+        ingress.poll({ received << it }, 2)
+
+        then:
+        removed
+        received.isEmpty()
+    }
+}

--- a/ical4j-integration-mail/src/test/groovy/org/ical4j/integration/mail/JakartaMailPublisherSpec.groovy
+++ b/ical4j-integration-mail/src/test/groovy/org/ical4j/integration/mail/JakartaMailPublisherSpec.groovy
@@ -1,0 +1,37 @@
+package org.ical4j.integration.mail
+
+import net.fortuna.ical4j.model.Calendar
+import org.ical4j.integration.mail.processor.CalendarAttachmentProcessor
+
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Flow
+import java.util.concurrent.TimeUnit
+
+class JakartaMailPublisherSpec extends AbstractGreenMailSpec {
+
+    def 'emits a calendar to a subscriber when a message arrives'() {
+        given: 'a subscribed publisher monitoring the inbox'
+        def session = mailSession()
+        def publisher = new JakartaMailPublisher(session, new CalendarAttachmentProcessor(), 'INBOX')
+        def latch = new CountDownLatch(1)
+        def received = new CopyOnWriteArrayList<Calendar>()
+        publisher.subscribe(new Flow.Subscriber<Calendar>() {
+            void onSubscribe(Flow.Subscription subscription) { subscription.request(Long.MAX_VALUE) }
+            void onNext(Calendar calendar) { received << calendar; latch.countDown() }
+            void onError(Throwable throwable) { }
+            void onComplete() { }
+        })
+
+        when: 'a calendar arrives after subscription'
+        new JakartaMailSMTPChannel(session).send { requestCalendar('pub-1', SENDER, [RECIPIENT]) }
+
+        then: 'the subscriber receives the parsed calendar'
+        latch.await(15, TimeUnit.SECONDS)
+        received.size() >= 1
+        received[0].getComponent('VEVENT').get().getRequiredProperty('UID').value == 'pub-1'
+
+        cleanup:
+        publisher.close()
+    }
+}

--- a/ical4j-integration-mail/src/test/groovy/org/ical4j/integration/mail/JakartaMailSMTPChannelIntegrationTest.groovy
+++ b/ical4j-integration-mail/src/test/groovy/org/ical4j/integration/mail/JakartaMailSMTPChannelIntegrationTest.groovy
@@ -1,72 +1,38 @@
 package org.ical4j.integration.mail
 
 import jakarta.mail.Message
-import jakarta.mail.Session
 import jakarta.mail.internet.MimeMessage
 import net.fortuna.ical4j.model.Calendar
-import net.fortuna.ical4j.model.ContentBuilder
 import org.ical4j.integration.mail.builder.EventAttachmentBuilder
-import org.testcontainers.containers.GenericContainer
-import org.testcontainers.spock.Testcontainers
-import spock.lang.Shared
-import spock.lang.Specification
 
-@Testcontainers
-class JakartaMailSMTPChannelIntegrationTest extends Specification {
+/**
+ * Verifies that caller-supplied addressing overrides derivation, sent end-to-end through GreenMail.
+ */
+class JakartaMailSMTPChannelIntegrationTest extends AbstractGreenMailSpec {
 
-    @Shared
-    GenericContainer mailhog = new GenericContainer('mailhog/mailhog')
-            .withExposedPorts(1025, 8025)
-
-    Session session
-
-    def setup() {
-        Properties sessionProps = []
-        sessionProps << [
-            'mail.smtp.host': mailhog.getContainerIpAddress(),
-            'mail.smtp.port': mailhog.getMappedPort(1025)
-        ]
-        session = Session.getDefaultInstance(sessionProps)
-        session.debug = true
-    }
-
-    def 'assert send calendar functionality works'() {
-        given: 'a calendar mail transport instance'
-//        CalendarMessageBuilder builder = new CalendarMessageBuilder().withSession(session)
-//            .withTemplate(new MessageTemplate()
-//                    .withFromAddress("sender@example.com")
-//                    .withToAddress("recipient@example.com")
-//                    .withSubject("Test calendar mail transport send")
-//                    .withTextBody("This is an integration test"))
-//
-        JakartaMailSMTPChannel channel = [(Calendar c) -> {
-            Optional<MimeMessage> message = new EventAttachmentBuilder().apply(c)
-            if (message.isPresent()) {
-                message.get().setFrom("sender@example.com")
-                message.get().setRecipients(Message.RecipientType.TO, "recipient@example.com")
-                return message
-            }
-            return Optional.empty()
-        }]
-
-        when: 'a calendar is submitted'
-        channel.send(() -> new ContentBuilder().calendar() {
-            prodid '-//Ben Fortuna//iCal4j 3.1//EN'
-            version '2.0'
-            method 'PUBLISH'
-            uid '123'
-            vevent {
-                uid '2'
-                summary 'Test Event 2'
-                organizer 'johnd@example.com', parameters: parameters { cn 'John Doe' }
-                dtstamp()
-                dtstart '20100810', parameters: parameters { value 'DATE' }
-                description 'Test Description 2', parameters: parameters { xparameter name: 'x-format', value: 'text/plain' }
-                xproperty 'X-test', value: 'test-value'
-            }
+    def 'caller-supplied recipients override derivation'() {
+        given: 'a builder whose caller overrides the recipient after build'
+        def session = mailSession()
+        def builder = new EventAttachmentBuilder(session)
+        def channel = new JakartaMailSMTPChannel(session, { Calendar c ->
+            Optional<MimeMessage> message = builder.apply(c)
+            message.ifPresent { it.setRecipients(Message.RecipientType.TO, RECIPIENT) }
+            return message
         })
 
-        then: 'it is successfully sent'
-        true
+        and: 'a calendar whose derived recipient would be someone else'
+        def calendar = requestCalendar('uid-2', SENDER, ['someoneelse@example.com'])
+
+        when: 'the calendar is sent'
+        boolean sent = channel.send { calendar }
+
+        then: 'the caller-supplied recipient is used, From is still derived from the organizer'
+        sent
+        greenMail.waitForIncomingEmail(5000, 1)
+
+        def messages = greenMail.receivedMessages
+        messages.length == 1
+        messages[0].getRecipients(Message.RecipientType.TO)[0].toString() == RECIPIENT
+        messages[0].getFrom()[0].toString() == SENDER
     }
 }

--- a/ical4j-integration-mail/src/test/groovy/org/ical4j/integration/mail/JakartaMailSMTPChannelTest.groovy
+++ b/ical4j-integration-mail/src/test/groovy/org/ical4j/integration/mail/JakartaMailSMTPChannelTest.groovy
@@ -1,26 +1,46 @@
 package org.ical4j.integration.mail
 
+import jakarta.mail.Message
+import jakarta.mail.Multipart
 
-import jakarta.mail.internet.MimeMessage
-import net.fortuna.ical4j.model.Calendar
-import net.fortuna.ical4j.model.property.immutable.ImmutableMethod
-import org.ical4j.integration.EgressChannel
-import spock.lang.Specification
+class JakartaMailSMTPChannelTest extends AbstractGreenMailSpec {
 
-class JakartaMailSMTPChannelTest extends Specification {
+    def 'derives recipients and delivers a calendar via SMTP'() {
+        given: 'a channel bound to the test session'
+        def channel = new JakartaMailSMTPChannel(mailSession())
+        def calendar = requestCalendar('uid-1', SENDER, [RECIPIENT])
 
-    def 'test publish with different email providers'() {
-        given: 'a calendar instance'
-        Calendar calendar = new Calendar().withDefaults().withProdId(JakartaMailSMTPChannel.name)
-                .withProperty(ImmutableMethod.PUBLISH).fluentTarget
+        when: 'a REQUEST calendar is sent'
+        boolean sent = channel.send { calendar }
 
-        when: 'the calendar is published'
-        EgressChannel<Calendar> channel = new JakartaMailSMTPChannel((c) -> {
-            return Optional.of(new MimeMessage(null))
-        })
-        channel.send {calendar}
+        then: 'it is delivered with addressing derived from organizer/attendees'
+        sent
+        greenMail.waitForIncomingEmail(5000, 1)
 
-        then: 'no errors are raised'
+        def messages = greenMail.receivedMessages
+        messages.length == 1
+        messages[0].getFrom()[0].toString() == SENDER
+        messages[0].getRecipients(Message.RecipientType.TO)[0].toString() == RECIPIENT
 
+        and: 'the message carries a text/calendar part'
+        messages[0].content instanceof Multipart
+        hasCalendarPart(messages[0].content as Multipart)
+    }
+
+    def 'reports failure when no message is produced'() {
+        given: 'a builder that produces nothing'
+        def channel = new JakartaMailSMTPChannel(mailSession(), { c -> Optional.empty() })
+
+        expect:
+        !channel.send { requestCalendar('uid-x', SENDER, [RECIPIENT]) }
+    }
+
+    private static boolean hasCalendarPart(Multipart multipart) {
+        for (int i = 0; i < multipart.count; i++) {
+            if (multipart.getBodyPart(i).isMimeType('text/calendar')) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/ical4j-integration-mail/src/test/groovy/org/ical4j/integration/mail/address/ITipRecipientStrategySpec.groovy
+++ b/ical4j-integration-mail/src/test/groovy/org/ical4j/integration/mail/address/ITipRecipientStrategySpec.groovy
@@ -1,0 +1,188 @@
+package org.ical4j.integration.mail.address
+
+import net.fortuna.ical4j.model.Calendar
+import net.fortuna.ical4j.model.ParameterList
+import net.fortuna.ical4j.model.component.VEvent
+import net.fortuna.ical4j.model.parameter.Cn
+import net.fortuna.ical4j.model.parameter.CuType
+import net.fortuna.ical4j.model.parameter.SentBy
+import net.fortuna.ical4j.model.property.Attendee
+import net.fortuna.ical4j.model.property.Method
+import net.fortuna.ical4j.model.property.Organizer
+import net.fortuna.ical4j.model.property.ProdId
+import net.fortuna.ical4j.model.property.Uid
+import net.fortuna.ical4j.model.property.immutable.ImmutableVersion
+import spock.lang.Specification
+
+class ITipRecipientStrategySpec extends Specification {
+
+    def strategy = new ITipRecipientStrategy()
+
+    def 'REQUEST routes from organizer to all attendees'() {
+        given:
+        Calendar calendar = cal(Method.VALUE_REQUEST,
+                organizer('boss@example.com'),
+                [attendee('a@example.com'), attendee('b@example.com')])
+
+        when:
+        def result = strategy.apply(calendar)
+
+        then:
+        result.isPresent()
+        result.get().from.get().address == 'boss@example.com'
+        result.get().to*.address == ['a@example.com', 'b@example.com']
+    }
+
+    def 'REPLY routes from the attendee to the organizer'() {
+        given:
+        Calendar calendar = cal(Method.VALUE_REPLY,
+                organizer('boss@example.com'),
+                [attendee('a@example.com')])
+
+        when:
+        def result = strategy.apply(calendar)
+
+        then:
+        result.isPresent()
+        result.get().from.get().address == 'a@example.com'
+        result.get().to*.address == ['boss@example.com']
+    }
+
+    def 'DECLINECOUNTER routes from organizer to the attendee'() {
+        given:
+        Calendar calendar = cal(Method.VALUE_DECLINECOUNTER,
+                organizer('boss@example.com'),
+                [attendee('a@example.com')])
+
+        when:
+        def result = strategy.apply(calendar)
+
+        then:
+        result.isPresent()
+        result.get().from.get().address == 'boss@example.com'
+        result.get().to*.address == ['a@example.com']
+    }
+
+    def 'PUBLISH derives sender only, no recipients'() {
+        given:
+        Calendar calendar = cal(Method.VALUE_PUBLISH, organizer('boss@example.com'), [])
+
+        when:
+        def result = strategy.apply(calendar)
+
+        then:
+        result.isPresent()
+        result.get().from.get().address == 'boss@example.com'
+        result.get().to.isEmpty()
+    }
+
+    def 'SENT-BY overrides the organizer From'() {
+        given:
+        Calendar calendar = cal(Method.VALUE_REQUEST,
+                organizer('boss@example.com', 'The Boss', 'assistant@example.com'),
+                [attendee('a@example.com')])
+
+        when:
+        def result = strategy.apply(calendar)
+
+        then:
+        result.get().from.get().address == 'assistant@example.com'
+    }
+
+    def 'CN populates the personal name'() {
+        given:
+        Calendar calendar = cal(Method.VALUE_REQUEST,
+                organizer('boss@example.com', 'The Boss'),
+                [attendee('a@example.com')])
+
+        when:
+        def result = strategy.apply(calendar)
+
+        then:
+        result.get().from.get().personal == 'The Boss'
+    }
+
+    def 'RESOURCE and ROOM attendees are excluded'() {
+        given:
+        Calendar calendar = cal(Method.VALUE_REQUEST,
+                organizer('boss@example.com'),
+                [attendee('a@example.com'), attendee('room@example.com', CuType.ROOM),
+                 attendee('projector@example.com', CuType.RESOURCE)])
+
+        when:
+        def result = strategy.apply(calendar)
+
+        then:
+        result.get().to*.address == ['a@example.com']
+    }
+
+    def 'non-mailto attendees are skipped'() {
+        given:
+        Calendar calendar = cal(Method.VALUE_REQUEST,
+                organizer('boss@example.com'),
+                [attendee('a@example.com'), new Attendee(URI.create('urn:uuid:1234'))])
+
+        when:
+        def result = strategy.apply(calendar)
+
+        then:
+        result.get().to*.address == ['a@example.com']
+    }
+
+    def 'REPLY with multiple attendees cannot be derived'() {
+        given:
+        Calendar calendar = cal(Method.VALUE_REPLY,
+                organizer('boss@example.com'),
+                [attendee('a@example.com'), attendee('b@example.com')])
+
+        expect:
+        strategy.apply(calendar).isEmpty()
+    }
+
+    def 'REQUEST without attendees cannot be derived'() {
+        given:
+        Calendar calendar = cal(Method.VALUE_REQUEST, organizer('boss@example.com'), [])
+
+        expect:
+        strategy.apply(calendar).isEmpty()
+    }
+
+    private static Calendar cal(String method, Organizer organizer, List<Attendee> attendees) {
+        VEvent event = new VEvent()
+        event = event.add(new Uid('1'))
+        if (organizer != null) {
+            event = event.add(organizer)
+        }
+        for (Attendee attendee : attendees) {
+            event = event.add(attendee)
+        }
+
+        Calendar calendar = new Calendar()
+        calendar = calendar.add(new ProdId('-//test//EN'))
+        calendar = calendar.add(ImmutableVersion.VERSION_2_0)
+        if (method != null) {
+            calendar = calendar.add(new Method(method))
+        }
+        calendar = calendar.add(event)
+        return calendar
+    }
+
+    private static Organizer organizer(String email, String cn = null, String sentBy = null) {
+        List params = []
+        if (cn != null) {
+            params << new Cn(cn)
+        }
+        if (sentBy != null) {
+            params << new SentBy('mailto:' + sentBy)
+        }
+        return new Organizer(new ParameterList(params), URI.create('mailto:' + email))
+    }
+
+    private static Attendee attendee(String email, CuType cuType = null) {
+        List params = []
+        if (cuType != null) {
+            params << cuType
+        }
+        return new Attendee(new ParameterList(params), URI.create('mailto:' + email))
+    }
+}

--- a/openspec/changes/complete-mail-integration/.openspec.yaml
+++ b/openspec/changes/complete-mail-integration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/complete-mail-integration/design.md
+++ b/openspec/changes/complete-mail-integration/design.md
@@ -1,0 +1,90 @@
+## Context
+
+`ical4j-integration-mail` exposes calendar-over-email transport via three flavors built on the `ical4j-integration-api` channel contracts:
+
+- **Egress** — `JakartaMailSMTPChannel` (`EgressChannel<Calendar>`) + `EventAttachmentBuilder` (`Function<Calendar, Optional<MimeMessage>>`).
+- **Ingress (poll)** — `JakartaMailPollingChannel` (`IngressChannel<Calendar>`) + `CalendarAttachmentProcessor` (`Function<MimeMessage, Optional<Calendar>>`).
+- **Reactive** — `JakartaMailPublisher extends SubmissionPublisher<Calendar>` driven by JavaMail `MessageCountListener`.
+
+Current state: egress mostly works; ingress is non-functional (store never connected, wrong folder, 1-based loop bug, always returns false, processor never returns the parsed calendar); the publisher is wired but never connects/opens/idles; tests assert nothing. Addressing is entirely caller-supplied today.
+
+Constraints: Java module system (`module-info.java` per module), Jakarta Mail (`com.sun.mail:jakarta.mail`), iCal4j core model, SLF4J logging, Spock/Groovy tests with Testcontainers.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Correct, testable round-trip of calendar data over email for all three flavors.
+- Derive `From`/`To`/`Cc` from `ORGANIZER`/`ATTENDEE` using the full iTIP (RFC 5546) `METHOD` matrix.
+- Preserve a caller override: explicit addressing always wins over derivation.
+- Real test coverage, including a mail-server round-trip.
+
+**Non-Goals:**
+- IMAP/POP3 provider-specific tuning beyond what JavaMail offers generically.
+- Full iTIP scheduling state machine (sequence handling, REPLY aggregation, free/busy). We address *transport + addressing*, not calendar reconciliation.
+- HTML email templating beyond the existing `STYLED-DESCRIPTION` passthrough.
+- S/MIME signing or DKIM.
+
+## Decisions
+
+### D1: Addressing as a dedicated strategy, method-aware
+Introduce a `RecipientStrategy` (working name) — `Function<Calendar, Optional<Addressing>>` — where `Addressing` carries `from`, `to[]`, `cc[]`. The default implementation branches on the calendar `METHOD`:
+
+```
+   METHOD            FROM            TO                CC
+   ──────            ────            ──                ──
+   REQUEST/CANCEL/   ORGANIZER       all ATTENDEEs     —
+   ADD
+   REPLY/COUNTER/    the ATTENDEE*   ORGANIZER         —
+   REFRESH
+   DECLINECOUNTER    ORGANIZER       the ATTENDEE*     —
+   PUBLISH           ORGANIZER       (caller-supplied) —
+```
+\* attendee-originated methods: the relevant attendee is identified by `SENT-BY`/the local identity when known; otherwise the single ATTENDEE present, else left to caller override.
+
+Rationale: keeps iTIP routing logic in one cohesive, unit-testable place; the builder stays focused on MIME assembly. Alternative (inline branching in `EventAttachmentBuilder`) rejected — couples MIME concerns to routing and is harder to test in isolation.
+
+### D2: Caller override semantics
+The builder derives addressing only for fields the caller has **not** already set on the `MimeMessage`. Concretely: derive, then apply derived `From`/recipients only where the message has none. This keeps the current integration-test usage (caller sets from/to) working unchanged. Alternative (override always) rejected — breaks back-compat and removes an escape hatch for non-iTIP sends.
+
+### D3: CAL-ADDRESS → InternetAddress mapping
+- Strip the `mailto:` scheme from the `CAL-ADDRESS` URI to get the email.
+- Use the `CN` parameter as the personal name.
+- `SENT-BY` on `ORGANIZER` overrides the `From` (sending on behalf of).
+- Non-`mailto:` calendar user addresses (e.g. `urn:`, `http:`) are skipped.
+- Attendee filtering: skip `CUTYPE=RESOURCE` and `CUTYPE=ROOM`; include all other roles by default.
+
+### D4: Session ownership
+`EventAttachmentBuilder` currently hardcodes `Session.getDefaultInstance(null)`. Move `Session` to an explicit constructor parameter on the builder (and ensure the SMTP channel uses the same session for `Transport`). Rationale: removes hidden global state and makes the SMTP host/port configuration deterministic. Alternative (keep default instance) rejected — fragile, order-dependent, untestable.
+
+### D5: iTIP method on Content-Type
+Set the `method` parameter on the calendar body part's content type (`text/calendar; method=REQUEST; charset=...`) derived from the calendar `METHOD`. Required for compliant clients (Outlook/Google) to treat the attachment as an invite rather than a plain `.ics` file.
+
+### D6: Ingress polling correctness
+Rewrite `JakartaMailPollingChannel.poll`:
+- `store.connect(...)`, `getFolder("INBOX")`, `open(READ_WRITE)`.
+- Iterate messages **1-based** (`getMessage(1..count)`), or use `folder.getMessages()`.
+- Honour `timeout` (bounded wait/retry); return `true` when ≥1 calendar consumed.
+- Implement `expunge(uid)` and the `autoExpunge` overload (set `DELETED` flag + `folder.expunge()` / `close(true)`).
+- Close folder/store in a finally block.
+
+### D7: Processor returns the calendar; handles raw bodies
+Fix `CalendarAttachmentProcessor` to **return** the parsed `Calendar`. Walk parts for `Content-Type: text/calendar` (attachment *or* inline body), not only `ATTACHMENT` disposition. Single-part `text/calendar` messages must also be handled.
+
+### D8: Reactive publisher actually fires
+`JakartaMailPublisher` must connect the store and `open()` each folder, then run an IMAP IDLE keepalive loop (background executor calling `IMAPFolder.idle()`), so `MessageCountEvent`s are delivered. Provide a clean `close()` that stops the keepalive and closes resources.
+
+### D9: Testing strategy
+- Unit-test `RecipientStrategy` across every iTIP method (table-driven).
+- Round-trip egress→ingress and egress→publisher against **GreenMail** (in-JVM SMTP+IMAP, supports IDLE) — chosen over MailHog because it provides IMAP and IDLE in-process, covering the poll and reactive-publisher paths without an external container. The existing MailHog-based SMTP integration test will be migrated to GreenMail.
+- Give existing tests real assertions (verify the server received the message; verify parsed calendar UID/summary).
+
+## Risks / Trade-offs
+
+- **IMAP IDLE flakiness in CI** → use GreenMail in-process; bound idle with timeouts; fall back to poll-based assertions if IDLE proves unstable.
+- **iTIP edge cases** (multiple attendees on REPLY, missing ORGANIZER, group addresses) → default conservatively and fall through to caller override; document unsupported cases rather than guessing.
+- **Constructor signature changes** (Session, strategy) are **BREAKING** for direct API users → acceptable; module is pre-1.0 and not consumed outside this repo, but call it out in the changelog.
+- **Test dependency footprint** → mail-server testcontainer/GreenMail is test-scope only; no runtime impact.
+
+## Open Questions
+
+- For attendee-originated methods with multiple ATTENDEEs and no local-identity hint, is "first attendee" acceptable, or should derivation return empty and force caller override? (Resolved: return empty and force caller override — see `mail-recipient-derivation` "Fall through" requirement.)

--- a/openspec/changes/complete-mail-integration/proposal.md
+++ b/openspec/changes/complete-mail-integration/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The `ical4j-integration-mail` module is only partially implemented. Egress (SMTP send) mostly works, but the ingress (polling) path is non-functional, the reactive publisher is inert scaffolding, recipient addressing must be set by the caller, and the tests assert nothing. As a result the module cannot reliably round-trip calendar data over email, which is its primary purpose.
+
+## What Changes
+
+- **Recipient derivation (new):** derive `From`/`To`/`Cc` from the calendar's `ORGANIZER` and `ATTENDEE` properties, following the full iTIP (RFC 5546) `METHOD` matrix so the message is routed in the correct direction (e.g. `REQUEST` → attendees, `REPLY`/`COUNTER` → organizer).
+- **Caller override retained:** automatic derivation is the default; if the caller sets addressing explicitly, that wins. Keeps existing usage working.
+- **Egress builder fixes:** set the iTIP `method` parameter on the calendar `Content-Type`; resolve the `Session` ownership (stop hardcoding `Session.getDefaultInstance(null)`); handle calendars beyond a single `VEVENT`.
+- **Ingress polling fixes:** connect the store, open `INBOX`, correct the 1-based message loop, honour `timeout`, return whether messages were consumed, and implement `expunge`/`autoExpunge`.
+- **Processor fix:** actually return the parsed `Calendar` (currently always returns `Optional.empty()`); handle raw `text/calendar` bodies, not only attachments.
+- **Reactive publisher fix:** connect the store, open folders, and add an IMAP IDLE keepalive so `MessageCountEvent`s actually fire.
+- **Tests:** replace no-op assertions with real ones; add MailHog/GreenMail round-trip coverage for poll and publish; add unit tests for recipient derivation across iTIP methods.
+
+## Capabilities
+
+### New Capabilities
+- `mail-recipient-derivation`: deriving email envelope addressing (`From`/`To`/`Cc`) from iCalendar `ORGANIZER`/`ATTENDEE` properties using the iTIP `METHOD` matrix, with caller override.
+- `mail-egress`: sending a calendar over SMTP — builds the MIME message, derives recipients by default, sets the iTIP `method` content-type parameter, takes an explicit `Session`.
+- `mail-ingress`: polling a mailbox for calendar objects — connect/open `INBOX`, correct iteration, `timeout`, return value, `expunge`/`autoExpunge`.
+- `mail-reactive`: a reactive `Publisher` that emits calendar objects as they arrive (store connect, folder open, IDLE keepalive).
+
+### Modified Capabilities
+<!-- None: openspec/specs/ is empty, so all behavior is captured as new specs. -->
+
+
+## Impact
+
+- Module: `ical4j-integration-mail` (`builder`, `processor`, channels, publisher).
+- Classes: `EventAttachmentBuilder`, `CalendarAttachmentProcessor`, `JakartaMailSMTPChannel`, `JakartaMailPollingChannel`, `JakartaMailPublisher`; likely a new addressing/strategy type.
+- Dependencies: `com.sun.mail:jakarta.mail`; test scope adds a mail server testcontainer (MailHog/GreenMail).
+- API: constructor signatures may change (e.g. channels/builder taking a `Session` and addressing strategy). No consumers outside this repo are tracked.

--- a/openspec/changes/complete-mail-integration/specs/mail-egress/spec.md
+++ b/openspec/changes/complete-mail-integration/specs/mail-egress/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Send a calendar over SMTP
+
+The system SHALL send an iCalendar object as an email via SMTP, building a MIME message that includes the calendar as a `text/calendar` part and reporting whether the send succeeded.
+
+#### Scenario: Calendar is delivered
+- **WHEN** a calendar is submitted to the SMTP channel and the SMTP server accepts it
+- **THEN** `send` returns `true` and the server receives a message with a `text/calendar` part
+
+#### Scenario: Send failure reported
+- **WHEN** the SMTP transport raises a messaging error
+- **THEN** `send` returns `false` and the error is logged
+
+### Requirement: Derive recipients by default with caller override
+
+The system SHALL derive `From`/`To`/`Cc` for the outgoing message from the calendar (per the recipient-derivation capability) by default. The system SHALL NOT overwrite any addressing field that the caller has already set on the message; explicitly supplied addressing always takes precedence.
+
+#### Scenario: Recipients derived automatically
+- **WHEN** a `REQUEST` calendar with an organizer and attendees is sent and the caller sets no addressing
+- **THEN** the message `From` is the organizer and the `To` contains the attendees
+
+#### Scenario: Caller addressing preserved
+- **WHEN** the caller sets the message `To` explicitly before sending
+- **THEN** the derived recipients do not replace the caller-supplied `To`
+
+### Requirement: Set the iTIP method on the calendar content type
+
+The system SHALL set the `method` parameter of the calendar body part's content type to the calendar's `METHOD` value (e.g. `text/calendar; method=REQUEST; charset=UTF-8`).
+
+#### Scenario: Method parameter present
+- **WHEN** a calendar with `METHOD:REQUEST` is sent
+- **THEN** the calendar body part content type includes `method=REQUEST`
+
+### Requirement: Use an explicitly provided mail Session
+
+The system SHALL use a mail `Session` supplied by the caller for message construction and transport rather than a global default instance.
+
+#### Scenario: Configured session used
+- **WHEN** the channel is constructed with a session configured for a specific SMTP host and port
+- **THEN** messages are transported using that host and port

--- a/openspec/changes/complete-mail-integration/specs/mail-ingress/spec.md
+++ b/openspec/changes/complete-mail-integration/specs/mail-ingress/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Poll a mailbox for calendar objects
+
+The system SHALL poll a mail store for calendar objects by connecting the store, opening the `INBOX` folder, and iterating its messages. For each message containing a `text/calendar` part (whether an attachment or an inline body), the system SHALL parse the calendar and pass it to the supplied consumer. The poll operation SHALL return `true` when one or more calendars were delivered to the consumer.
+
+#### Scenario: Calendar parsed and consumed
+- **WHEN** the inbox contains a message with a `text/calendar` attachment
+- **THEN** the consumer receives the parsed calendar and `poll` returns `true`
+
+#### Scenario: Inline calendar body handled
+- **WHEN** the inbox contains a single-part message whose content type is `text/calendar`
+- **THEN** the consumer receives the parsed calendar
+
+#### Scenario: No new messages
+- **WHEN** the inbox contains no messages with calendar content
+- **THEN** the consumer is not invoked and `poll` returns `false`
+
+### Requirement: Honour the poll timeout
+
+The system SHALL bound the time spent waiting for messages by the supplied `timeout` value and return once the timeout elapses if no messages are available.
+
+#### Scenario: Timeout elapses with empty inbox
+- **WHEN** `poll` is called with a timeout and no messages arrive
+- **THEN** `poll` returns within approximately the timeout and reports `false`
+
+### Requirement: Remove processed messages on request
+
+The system SHALL support removing processed messages from the mailbox. When `autoExpunge` is requested, consumed messages SHALL be flagged deleted and expunged; the `expunge(uid)` operation SHALL remove the identified message.
+
+#### Scenario: Auto-expunge removes consumed message
+- **WHEN** `poll` is called with `autoExpunge=true` and a calendar message is consumed
+- **THEN** that message is removed from the inbox
+
+#### Scenario: Expunge by identifier
+- **WHEN** `expunge(uid)` is called for a message present in the inbox
+- **THEN** that message is removed and the call returns `true`

--- a/openspec/changes/complete-mail-integration/specs/mail-reactive/spec.md
+++ b/openspec/changes/complete-mail-integration/specs/mail-reactive/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Publish calendar objects as they arrive
+
+The system SHALL provide a reactive `Publisher` that emits calendar objects to subscribers as matching messages arrive in the monitored mail folders. The publisher SHALL connect the mail store and open each monitored folder so that new-message events are delivered, parse `text/calendar` content from each new message, and submit the parsed calendar to subscribers.
+
+#### Scenario: New message emitted to subscriber
+- **WHEN** a subscriber is registered and a message with calendar content arrives in a monitored folder
+- **THEN** the subscriber receives the parsed calendar
+
+#### Scenario: Non-calendar message ignored
+- **WHEN** a message without calendar content arrives in a monitored folder
+- **THEN** no item is emitted to subscribers
+
+### Requirement: Maintain a live connection for event delivery
+
+The system SHALL maintain the folder connection (e.g. via an IMAP IDLE keepalive) for as long as the publisher is active so that message-count events continue to fire, and SHALL release the connection and stop the keepalive when the publisher is closed.
+
+#### Scenario: Events continue over time
+- **WHEN** the publisher has been active beyond an idle interval and a new message arrives
+- **THEN** the subscriber still receives the parsed calendar
+
+#### Scenario: Close releases resources
+- **WHEN** the publisher is closed
+- **THEN** the keepalive stops and the store and folders are closed

--- a/openspec/changes/complete-mail-integration/specs/mail-recipient-derivation/spec.md
+++ b/openspec/changes/complete-mail-integration/specs/mail-recipient-derivation/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Derive envelope addressing from calendar properties
+
+The system SHALL derive email envelope addressing (`From`, `To`, `Cc`) from an iCalendar object's `ORGANIZER` and `ATTENDEE` properties. A `CAL-ADDRESS` value SHALL be mapped to an email address by stripping the `mailto:` URI scheme, and the `CN` parameter SHALL be used as the address personal name. Calendar user addresses that do not use the `mailto:` scheme SHALL be skipped.
+
+#### Scenario: Organizer mapped to From
+- **WHEN** a calendar has `ORGANIZER:mailto:jane@example.com` with `CN=Jane Doe`
+- **THEN** the derived `From` is `Jane Doe <jane@example.com>`
+
+#### Scenario: Non-mailto address skipped
+- **WHEN** an `ATTENDEE` has a `CAL-ADDRESS` of `urn:uuid:1234`
+- **THEN** that attendee is not included in any derived recipient list
+
+### Requirement: Route messages per the iTIP METHOD matrix
+
+The system SHALL choose the direction of addressing based on the calendar `METHOD` property per RFC 5546. For organizer-originated methods (`REQUEST`, `CANCEL`, `ADD`) the `From` SHALL be the `ORGANIZER` and the `To` SHALL be all `ATTENDEE`s. For attendee-originated methods (`REPLY`, `COUNTER`, `REFRESH`) the `From` SHALL be the relevant attendee and the `To` SHALL be the `ORGANIZER`. For `DECLINECOUNTER` the `From` SHALL be the `ORGANIZER` and the `To` SHALL be the relevant attendee.
+
+#### Scenario: REQUEST goes to attendees
+- **WHEN** a calendar has `METHOD:REQUEST`, an organizer, and two attendees
+- **THEN** the derived `From` is the organizer and the derived `To` contains both attendees
+
+#### Scenario: REPLY goes to the organizer
+- **WHEN** a calendar has `METHOD:REPLY`, an organizer, and a single attendee
+- **THEN** the derived `To` is the organizer and the derived `From` is the attendee
+
+#### Scenario: DECLINECOUNTER goes to the attendee
+- **WHEN** a calendar has `METHOD:DECLINECOUNTER`, an organizer, and a single attendee
+- **THEN** the derived `From` is the organizer and the derived `To` is the attendee
+
+### Requirement: Honour SENT-BY and resource filtering
+
+The system SHALL use the `ORGANIZER` `SENT-BY` parameter, when present, as the `From` address (sending on behalf of the organizer). The system SHALL exclude attendees whose `CUTYPE` parameter is `RESOURCE` or `ROOM` from derived recipient lists.
+
+#### Scenario: SENT-BY overrides organizer From
+- **WHEN** an `ORGANIZER:mailto:boss@example.com` has `SENT-BY="mailto:assistant@example.com"` and the method is `REQUEST`
+- **THEN** the derived `From` is `assistant@example.com`
+
+#### Scenario: Room resource excluded from recipients
+- **WHEN** a `REQUEST` calendar has a human attendee and an attendee with `CUTYPE=ROOM`
+- **THEN** the derived `To` contains only the human attendee
+
+### Requirement: Fall through when addressing cannot be derived
+
+The system SHALL return no derived addressing when the required properties for the method are absent (e.g. `PUBLISH` with no explicit recipients, or an attendee-originated method without an identifiable attendee), leaving the caller responsible for addressing.
+
+#### Scenario: PUBLISH has no derivable recipients
+- **WHEN** a calendar has `METHOD:PUBLISH` and an organizer but no attendees
+- **THEN** no `To` recipients are derived

--- a/openspec/changes/complete-mail-integration/tasks.md
+++ b/openspec/changes/complete-mail-integration/tasks.md
@@ -1,0 +1,44 @@
+## 1. Test harness
+
+- [x] 1.1 Add GreenMail (SMTP + IMAP, in-JVM) at test scope to `ical4j-integration-mail/build.gradle` and version catalog
+- [x] 1.2 Add a small GreenMail Spock base/helper for starting SMTP+IMAP and building test `Session`s
+
+## 2. Recipient derivation
+
+- [x] 2.1 Add an `Addressing` value type (`from`, `to[]`, `cc[]`) and a `RecipientStrategy` (`Function<Calendar, Optional<Addressing>>`)
+- [x] 2.2 Implement CAL-ADDRESS → `InternetAddress` mapping: strip `mailto:`, use `CN` as personal name, skip non-`mailto:` addresses
+- [x] 2.3 Implement the iTIP METHOD matrix (REQUEST/CANCEL/ADD, REPLY/COUNTER/REFRESH, DECLINECOUNTER, PUBLISH)
+- [x] 2.4 Honour `ORGANIZER` `SENT-BY` for `From`; exclude `CUTYPE=RESOURCE`/`ROOM` attendees
+- [x] 2.5 Return empty when addressing cannot be derived (fall through to caller override)
+- [x] 2.6 Unit-test derivation across every iTIP method (table-driven)
+
+## 3. Egress
+
+- [x] 3.1 Give `EventAttachmentBuilder` an explicit `Session` (remove `Session.getDefaultInstance(null)`)
+- [x] 3.2 Set the iTIP `method` parameter on the calendar body part content type
+- [x] 3.3 Apply derived addressing only to fields the caller has not already set (caller override)
+- [x] 3.4 Handle calendars with components beyond a single `VEVENT`
+- [x] 3.5 Ensure `JakartaMailSMTPChannel` uses the same `Session` for transport
+- [x] 3.6 Replace the no-op assertions in the SMTP unit + integration tests with real ones (assert the server received the message and addressing)
+
+## 4. Ingress (polling)
+
+- [x] 4.1 Fix `CalendarAttachmentProcessor` to return the parsed `Calendar`; handle inline `text/calendar` bodies as well as attachments
+- [x] 4.2 Rewrite `JakartaMailPollingChannel.poll`: connect store, open `INBOX`, iterate 1-based, return `true` when calendars consumed
+- [x] 4.3 Honour the `timeout` parameter
+- [x] 4.4 Implement `expunge(uid)` and the `autoExpunge` overload; close folder/store in a finally block
+- [x] 4.5 Add round-trip tests (egress → poll) against the test mail server, with assertions on parsed calendar and expunge
+
+## 5. Reactive publisher
+
+- [x] 5.1 Connect the store and open monitored folders in `JakartaMailPublisher`
+- [x] 5.2 Add an IMAP IDLE keepalive loop on a background executor so `MessageCountEvent`s fire
+- [x] 5.3 Parse `text/calendar` content and `submit` to subscribers; ignore non-calendar messages
+- [x] 5.4 Implement clean `close()` that stops the keepalive and releases store/folders
+- [x] 5.5 Add a round-trip test (egress → publisher subscriber receives calendar)
+
+## 6. Wrap-up
+
+- [x] 6.1 Update `module-info.java` exports if new packages are introduced (e.g. addressing)
+- [x] 6.2 Run `openspec validate complete-mail-integration --strict` and the module test suite green
+- [x] 6.3 Note BREAKING constructor signature changes (Session, strategy) in the changelog/README

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours


### PR DESCRIPTION
## Why

The `ical4j-integration-mail` module was only partially implemented: egress mostly worked, but the ingress (polling) path was non-functional, the reactive publisher was inert scaffolding, recipient addressing had to be set by the caller, and the tests asserted nothing. This completes the module so it reliably round-trips calendar data over email.

## What changed

**Recipient derivation (new `org.ical4j.integration.mail.address`)**
- `Addressing`, `RecipientStrategy`, `ITipRecipientStrategy` implementing the full iTIP (RFC 5546) `METHOD` matrix:
  - REQUEST/CANCEL/ADD → organizer → attendees
  - REPLY/COUNTER/REFRESH → attendee → organizer
  - DECLINECOUNTER → organizer → attendee
  - PUBLISH → sender only (recipients supplied by caller)
- `mailto:` stripping, `CN` personal names, `SENT-BY` override, `CUTYPE=RESOURCE/ROOM` exclusion; returns empty (caller override) when underivable.

**Egress** — explicit `Session` (no more `Session.getDefaultInstance(null)`), `text/calendar; method=…` content type, multi-component support, derived addressing that never overwrites caller-set fields. `JakartaMailSMTPChannel` transports via its own session.

**Ingress** — `CalendarAttachmentProcessor` now actually returns the parsed calendar and handles inline + attachment `text/calendar`. `JakartaMailPollingChannel` rewritten: connect store, open `INBOX`, correct iteration, real `timeout`, accurate return value, `expunge(uid)` / `autoExpunge` with resource cleanup.

**Reactive** — `JakartaMailPublisher` connects + opens folders, runs an `IMAPFolder.idle()` keepalive (polling fallback for non-IMAP), with a clean `close()`.

**Tests** — migrated off MailHog/Testcontainers to in-JVM **GreenMail**; 17 tests covering derivation (table-driven across methods), SMTP send + caller override, poll + expunge round-trips, and an IMAP IDLE publish round-trip.

## Breaking changes

Mail channel/builder constructors now require an explicit Jakarta Mail `Session`. Documented in the README. Accepted as pre-1.0.

## Verification

- `./gradlew build` — SUCCESSFUL (incl. OSGi/bnd jar, javadoc, sources)
- Mail test suite: **17 tests, 0 failures**
- `openspec validate complete-mail-integration --strict` — valid

This change was developed spec-driven; the proposal, design, specs, and tasks are included under `openspec/changes/complete-mail-integration/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)