### PR TITLE
fix(build): make javadoc resilient so publishing doesn't fail on external links

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,10 @@ iCalendar support for integration architectures like Apache Camel
     }
 
     javadoc {
+        // External javadoc links are fetched at build time and 'latest' redirects can 404 on
+        // package-list, which would otherwise fail the publish. Don't let flaky link resolution
+        // (or stray @link warnings) break the build.
+        failOnError = false
         if (JavaVersion.current().isJava8Compatible()) {
             options.addStringOption('Xdoclint:none', '-quiet')
         }
@@ -88,9 +92,7 @@ iCalendar support for integration architectures like Apache Camel
             links 'https://docs.oracle.com/en/java/javase/11/docs/api/',
                     'https://javadoc.io/doc/org.mnode.ical4j/ical4j/latest',
                     'https://javadoc.io/doc/org.mnode.ical4j/ical4j-vcard/latest',
-                    'https://javadoc.io/doc/com.sun.mail/jakarta.mail/latest',
-                    'https://javadoc.io/doc/jakarta.servlet/jakarta.servlet-api/latest',
-                    'https://javadoc.io/doc/org.igniterealtime.smack/smack-core/latest'
+                    'https://javadoc.io/doc/com.sun.mail/jakarta.mail/latest'
         }
     }
 


### PR DESCRIPTION
## Problem

After the Maven Central publishing change (#21) and once signing secrets were added, the snapshot-publish run progressed past signing to `:ical4j-integration-api:javadoc`, which **failed**:

```
error: Error fetching URL: https://javadoc.io/doc/jakarta.servlet/jakarta.servlet-api/latest/
       (FileNotFoundException: .../6.2.0-M2/package-list)
> Task :ical4j-integration-api:javadoc FAILED
```

The `javadoc { options { links … } }` block fetches `package-list` from external sites at build time. The `…/latest` URLs redirect to versions that 404 on `package-list`, which makes javadoc — and therefore the publish — fail. It's environmental (passed locally where `element-list` resolved and only warned), so it didn't show up in the PR's `check` build (which doesn't run javadoc).

## Fix

- `failOnError = false` on the javadoc task so flaky external-link resolution (and pre-existing stray `@link` warnings) can't break the publish.
- Remove the two links that aren't dependencies of the published modules: `jakarta.servlet-api` (the one that 404'd) and `smack-core`.

Javadoc is still generated; cross-links resolve when the network cooperates.

## Verification

`./gradlew clean build` green locally (javadoc + javadoc jar produced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)