### PR TITLE
fix(build): enable Central Portal snapshot publishing (vanniktech 0.34.0 + Gradle 8.5)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,6 +14,11 @@ targeting the Sonatype **Central Portal** under the `org.ical4j` namespace.
 
 `publish-release.yml` can also be run manually via **workflow_dispatch**.
 
+> **Snapshots** must be enabled for the `org.ical4j` namespace in the Central Portal
+> (central.sonatype.com → namespace settings) before snapshot publishing will succeed.
+> Snapshot publishing to the Central Portal requires the vanniktech plugin **0.31.0+**
+> (this project uses 0.34.0, which requires **Gradle 8.5+**).
+
 The release version is derived from the tag by the
 [axion-release](https://github.com/allegro/axion-release-plugin) plugin, so the publish
 jobs check out with `fetch-depth: 0` to make tags available.

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'pl.allegro.tech.build.axion-release' version '1.15.1'
     id 'biz.aQute.bnd.builder' version "$bndVersion" apply false
-    id 'com.vanniktech.maven.publish' version '0.29.0' apply false
+    id 'com.vanniktech.maven.publish' version '0.34.0' apply false
 }
 
 scmVersion {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Problem

With secrets and the javadoc fix in place, the snapshot-publish run got all the way to the upload and then failed:

```
> Task :…:publishMavenPublicationToMavenCentralRepository FAILED
> Snapshots are not supported when publishing through the central portal.
```

vanniktech **0.29.0** (the version pinned because it works on Gradle 8.4) does not support snapshots via the Central Portal. Central Portal snapshot support was added in vanniktech **0.31.0**, which raises the minimum Gradle to **8.5**.

## Fix

| | before | after |
| --- | --- | --- |
| vanniktech plugin | 0.29.0 | **0.34.0** (newest on the 8.5 floor; 0.35 needs 8.13, 0.36 needs 9.0) |
| Gradle wrapper | 8.4 | **8.5** |

Also documents in `RELEASING.md` that snapshots must be enabled for the `org.ical4j` namespace in the Central Portal.

## Verification

`./gradlew publishToMavenLocal` green on Gradle 8.5 — both modules produce signed main/sources/javadoc artifacts with valid POMs.

## Action required (one-time, manual)

Enable snapshots for the `org.ical4j` namespace at central.sonatype.com → namespace settings. Without it, snapshot publishing will still be rejected by the Portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)